### PR TITLE
[master] account info schemas + rating mockup (sort of)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ venv/
 # ide
 __pycache__/
 .idea/
+
+#jupyter
+.ipynb_checkpoints/

--- a/data/account_standing.json
+++ b/data/account_standing.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "accountStanding": {
+      "reputation": {
+        "overall": "float",
+        "count": "int"
+      }
+    }
+  },
+  "key": {
+      "accountCreatedAt": "string",
+      "userName": "string",
+      "uuid": "int"
+  }
+}

--- a/data/rating.json
+++ b/data/rating.json
@@ -4,6 +4,7 @@
       "reputation": "float",
       "genreReputation": "float"
     },
+    "overallRating": "float",
     "ratingCriteria": {
       "complexity": "float",
       "consistency": "float",
@@ -16,19 +17,22 @@
       "technicality": "float",
       "tenacity": "float"
     },
-    "reviewComment": "string",
+    "ratingComment": "string",
+    "ratingId": "string",
     "source": {
       "albumName": "string",
       "artistName": "string",
       "releaseDate": "string",
       "label": "string",
+      "genre": "enumeration",
       "metadata": {
         "rating": {
           "amount": "int",
           "consensus": "float",
           "initial": "string"
         }
-      }
+      },
+      "relativeWeight": "float"
     }
   },
   "key": {

--- a/data/rating_signal.json
+++ b/data/rating_signal.json
@@ -1,0 +1,18 @@
+{
+  "data": {
+    "accountStanding": {
+      "reputation": "float",
+      "genreReputation": "float"
+    },
+    "ratingId": "string",
+    "ratingSignal": {
+      "thumbsUp": "int",
+      "thumbsDown": "int"
+    }
+  },
+  "key": {
+      "accountCreatedAt": "string",
+      "userName": "string",
+      "uuid": "int"
+  }
+}

--- a/data/sample_ratings.py
+++ b/data/sample_ratings.py
@@ -7,10 +7,11 @@ def generate_random_ratings(length):
     for x in range(length):
         rating =  {
             "data": {
-                "acountStanding": {
+                "accountStanding": {
                     "reputation": random.uniform(0, 10),
                     "genreReputation": random.uniform(0, 10)
                 },
+                "overallRating": random.uniform(0, 10),
                 "ratingCriteria": {
                     "complexity": random.uniform(0, 10),
                     "consistency": random.uniform(0, 10),

--- a/exporatory/account_repuatation.ipynb
+++ b/exporatory/account_repuatation.ipynb
@@ -1,0 +1,56 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2rc1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/utils/consensus.py
+++ b/utils/consensus.py
@@ -1,15 +1,38 @@
 import json
+import numpy as np
+from json_util import (
+    get_nested,
+    set_nested
+)
 
 from data.sample_ratings import generate_random_ratings
 
 # temporary data read
 
 
-def consensus_rating(length):
+def rating_weight(length):
     ratings = generate_random_ratings(length)
-    print(ratings[0])
+    for rating in ratings:
+        rep = get_nested(rating, 'data.accountStanding.reputation')
+        g_rep = get_nested(rating, 'data.accountStanding.genreReputation')
+
+        relative_weight = (rep+g_rep)/2
+
+        set_nested(rating, 'data.relativeWeight', relative_weight)
+
+    return ratings
+
+
+def calculate_rating(new_ratings):
+    overall_rating = [get_nested(x, 'data.overallRating') for x in new_ratings]
+    weights = [get_nested(x, 'data.relativeWeight') for x in new_ratings]
+
+    weighted_consensus = round(np.average(overall_rating, weights=weights), 2)
+
+    return weighted_consensus
 
 
 if __name__ == '__main__':
     length = 1000
-    consensus_rating(length)
+    weights = rating_weight(length)
+    calculate_rating(weights)

--- a/utils/json_util.py
+++ b/utils/json_util.py
@@ -1,0 +1,48 @@
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger('json_util')
+
+
+def get_nested(payload, jpath):
+    """
+    Utility function to get nested json values
+    :param payload:
+    :param jpath:
+    :return:
+    """
+    path_list = jpath.split('.')
+    # logger.info(f' Path List: {path_list}')
+
+    control = None
+    for jpath in path_list:
+        control = payload.get(str(jpath))
+        payload = control
+
+        # logger.info(f' Return Value: {control}')
+
+    return control
+
+
+def set_nested(payload, jpath, set_value):
+    """
+    Utility function to set nested json values into model
+    :param payload:
+    :param jpath:
+    :param set_value:
+    :return:
+    """
+    path_list = jpath.split('.')
+    # logger.info(f' Path List: {path_list}')
+
+    model = payload.copy()
+    for jpath in path_list[:len(path_list) - 1]:
+        control = model[jpath]
+        model = control
+
+    to_set = path_list[-1]
+    model[to_set] = set_value
+
+    # logger.info(f' Set Path: {to_set}: {set_value}')
+
+    return payload


### PR DESCRIPTION
**We can figure out branching later**

In 6b9c0ba:

**NEW**
- Added some mockups for schemas
- `account_standing.json` - self explanatory
- `rating_signal.json` - basically the signal of a rating for account standing calculations
- Added the json util that I've been hooked on `json_util.py`

**IMPROVEMENTS**
- Added some fields to `rating.json`
- Added some introductory calculations in `consensus.py` for reputation weighted rating algo
